### PR TITLE
port-forward feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
 # kurun
-Just like `go run main.go` but executed inside Kubernetes with one command.
+
+- Just like `go run main.go` but executed inside Kubernetes with one command.
+- Just like `kubectl port-forward ...` just the other way around!
+
+### Synopsis
+
+```
+Usage:
+  kurun [command]
+
+Available Commands:
+  help         Help about any command
+  port-forward Just like `kubectl port-forward ...`, just the other way around!
+  run          Just like `go run main.go` but executed inside Kubernetes with one command.
+
+Flags:
+  -h, --help               help for kurun
+      --namespace string   Namespace to use for the Pod/Service
+
+Use "kurun [command] --help" for more information about a command.
+```
 
 ### Prerequisites
 
-A Kubernetes cluster, where you have access to the image storage of the cluster itself, for example:
-- Docker for Mac Edge with Kubernetes enabled
-- Minikube with the Registry addon enabled
+- A Kubernetes cluster, where you have access to the image storage of the cluster itself, for example:
+	- Docker for Mac Edge with Kubernetes enabled
+	- Minikube with the Registry addon enabled
+- kubectl
+- [inlets CLI](https://github.com/alexellis/inlets#install-the-cli) (for `port-forward` only)
 
 ### Installation
 
@@ -22,15 +44,18 @@ go get github.com/banzaicloud/kurun
 ### Usage
 
 ```bash
-kurun test.go arg1 arg2 arg3
+kurun run test.go arg1 arg2 arg3
 ```
 
+```bash
+kurun port-forward localhost:4443
+```
 
-### `kurun` is like `go run`
+### `kurun` is like `go run` to Kubernetes
 
 The `go run` command is a really convenient CLI subcommand for executing `Golang` code during the development phase. A lot of our applications are making calls to the Kubernetes API and we needed a quick utility to execute the **Go code inside Kubernetes** very quickly. That's why we have written `kurun`, a dirty little bash utility, to execute Go code inside Kubernetes with a oneliner: 
 
-`kurun main.go` 
+`kurun run main.go` 
 
 It's that easy.
 
@@ -80,7 +105,7 @@ git clone git@github.com:banzaicloud/kurun.git
 cd kurun
 # Download the dependencies, this is just a one-time step to get the k8s libraries
 go get ./...
-./kurun example/test.go
+./kurun run example/test.go
 Sending build context to Docker daemon  31.05MB
 Step 1/2 : FROM alpine
  ---> 3fd9065eaf02
@@ -92,5 +117,58 @@ Successfully tagged kurun:latest
 List of Kubernetes nodes:
 - docker-for-desktop - map[beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux kubernetes.io/hostname:docker-for-desktop node-role.kubernetes.io/master:]
 ```
+
+### `kurun` is like `kubectl port-forward` to Kubernetes (and not out!)
+
+`kurun` is capable of port forwarding your local application into a Kubernetes cluster with the help of a few tricks, it uses [inlets](https://github.com/alexellis/inlets) and `kubectl port-forward` to achieve this. This is extremely useful for rapid development of Kubernetes admission webhooks for example.
+
+Start a Python SimpleHTTPServer on port 4443 on your machine:
+```bash
+$ python -m SimpleHTTPServer 4443
+```
+
+In another terminal session proxy this application into Kubernetes under the Service name `python-server`:
+`kurun port-forward --servicename python-server localhost:4443`
+
+In a third terminal session proxy this application into Kubernetes under the Service name `python-server`:
+```
+kubectl run alpine --rm --image alpine -it
+If you don't see a command prompt, try pressing enter.
+
+/ # apk add curl
+fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
+fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
+(1/4) Installing ca-certificates (20190108-r0)
+(2/4) Installing nghttp2-libs (1.38.0-r0)
+(3/4) Installing libcurl (7.65.1-r0)
+(4/4) Installing curl (7.65.1-r0)
+Executing busybox-1.30.1-r2.trigger
+Executing ca-certificates-20190108-r0.trigger
+OK: 7 MiB in 18 packages
+
+/ # curl http://python-server
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>
+<title>Directory listing for /</title>
+<body>
+<h2>Directory listing for /</h2>
+<hr>
+<ul>
+<li><a href=".git/">.git/</a>
+<li><a href=".gitignore">.gitignore</a>
+<li><a href=".goreleaser.yml">.goreleaser.yml</a>
+<li><a href="dist/">dist/</a>
+<li><a href="example/">example/</a>
+<li><a href="go.mod">go.mod</a>
+<li><a href="go.sum">go.sum</a>
+<li><a href="kurun">kurun</a>
+<li><a href="kurun.go">kurun.go</a>
+<li><a href="LICENSE">LICENSE</a>
+<li><a href="README.md">README.md</a>
+</ul>
+<hr>
+</body>
+</html>
+```
+
 
 For some more details and examples please read this [post](https://banzaicloud.com/blog/kurun).

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ List of Kubernetes nodes:
 - docker-for-desktop - map[beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux kubernetes.io/hostname:docker-for-desktop node-role.kubernetes.io/master:]
 ```
 
-### `kurun` is like `kubectl port-forward` to Kubernetes (and not out!)
+### `kurun` is like `kubectl port-forward` into Kubernetes (and not out from!)
 
 `kurun` is capable of port forwarding your local application into a Kubernetes cluster with the help of a few tricks, it uses [inlets](https://github.com/alexellis/inlets) and `kubectl port-forward` to achieve this. This is extremely useful for rapid development of Kubernetes admission webhooks for example.
 

--- a/kurun.go
+++ b/kurun.go
@@ -142,9 +142,10 @@ var runCmd = &cobra.Command{
 }
 
 var exposeCmd = &cobra.Command{
-	Use:   "port-forward [flags] upstream",
-	Short: "Just like `kubectl port-forward ...`, just the other way around!",
-	Args:  cobra.MinimumNArgs(1),
+	Use:     "port-forward [flags] upstream",
+	Short:   "Just like `kubectl port-forward ...`, just the other way around!",
+	Example: "kurun port-forward --namespace apps localhost:4443",
+	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		done := make(chan bool, 1)


### PR DESCRIPTION
Kurun with this PR is capable of port forwarding your local application into a Kubernetes cluster with the help of a few tricks, it uses [inlets](https://github.com/alexellis/inlets) and `kubectl port-forward` to achieve this. This is extremely useful for rapid development of Kubernetes admission webhooks for example.