### PR TITLE
Fix kubectl run overrides

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -122,8 +122,8 @@ func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&serviceAccount, "serviceaccount", "", "Service account to set for the pod")
-	cmd.PersistentFlags().StringArrayVarP(&podEnv, "env", "e", []string{}, "Environment variables to pass to the pod's containers")
 	cmd.PersistentFlags().StringVar(&overrides, "overrides", "", "An inline JSON override for the generated pod object, e.g. '{\"metadata\":{\"name\":\"my-pod\"}}'")
+	cmd.PersistentFlags().StringArrayVarP(&podEnv, "env", "e", nil, "Environment variables to pass to the pod's containers")
 
 	return cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -81,6 +81,7 @@ func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 
 			if serviceAccount != "" {
 				kubectlArgs = append(kubectlArgs, fmt.Sprintf("--serviceaccount=%s", serviceAccount))
+				"--override-type=strategic",
 			}
 
 			for _, e := range podEnv {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -46,7 +47,18 @@ func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 
 			podName := strings.Split(image, ":")[0]
 
-			podOverride := map[string]interface{}{
+			kubectlArgs := []string{
+				"run", podName,
+				mode,
+				"--image=docker.io/library/" + image,
+				"--quiet",
+				"--image-pull-policy=IfNotPresent",
+				"--restart=Never",
+				"--rm",
+				"--override-type=strategic",
+			}
+
+			limitsPatch := map[string]interface{}{
 				"spec": corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -63,26 +75,23 @@ func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 				},
 			}
 
-			overrides, err := json.Marshal(podOverride)
+			limitsOverride, err := json.Marshal(limitsPatch)
 			if err != nil {
 				return err
 			}
 
-			kubectlArgs := []string{
-				"run", podName,
-				mode,
-				"--image=docker.io/library/" + image,
-				"--quiet",
-				"--image-pull-policy=IfNotPresent",
-				"--restart=Never",
-				"--rm",
-				"--overrides=" + string(overrides),
-			}
+			combinedOverride := limitsOverride
 
 			if serviceAccount != "" {
-				kubectlArgs = append(kubectlArgs, fmt.Sprintf("--serviceaccount=%s", serviceAccount))
-				"--override-type=strategic",
+				serviceAccountPatch := fmt.Sprintf(`{"spec":{"serviceAccount":"%s"}}`, serviceAccount)
+				serviceAccountOverride, err := jsonpatch.MergeMergePatches(combinedOverride, []byte(serviceAccountPatch))
+				if err != nil {
+					return err
+				}
+				combinedOverride = serviceAccountOverride
 			}
+
+			kubectlArgs = append(kubectlArgs, fmt.Sprintf("--overrides=%s", string(combinedOverride)))
 
 			for _, e := range podEnv {
 				kubectlArgs = append(kubectlArgs, fmt.Sprintf("--env=%s", e))

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -15,6 +15,7 @@ import (
 
 func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 	var serviceAccount string
+	var overrides string
 	var podEnv []string
 
 	cmd := &cobra.Command{
@@ -91,6 +92,14 @@ func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 				combinedOverride = serviceAccountOverride
 			}
 
+			if overrides != "" {
+				overridesOverride, err := jsonpatch.MergeMergePatches(combinedOverride, []byte(overrides))
+				if err != nil {
+					return err
+				}
+				combinedOverride = overridesOverride
+			}
+
 			kubectlArgs = append(kubectlArgs, fmt.Sprintf("--overrides=%s", string(combinedOverride)))
 
 			for _, e := range podEnv {
@@ -114,6 +123,7 @@ func NewRunCommand(rootParams *rootCommandParams) *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&serviceAccount, "serviceaccount", "", "Service account to set for the pod")
 	cmd.PersistentFlags().StringArrayVarP(&podEnv, "env", "e", []string{}, "Environment variables to pass to the pod's containers")
+	cmd.PersistentFlags().StringVar(&overrides, "overrides", "", "An inline JSON override for the generated pod object, e.g. '{\"metadata\":{\"name\":\"my-pod\"}}'")
 
 	return cmd
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The first thing this PR fixes an issue with kubectl run's `--overrides` flag, as the default override type seem to be overwriting any other configurations specified by flags, such as `--command` and `--env`, but specifying the `strategic` override type fixes this issue (see [here](https://github.com/kubernetes/kubernetes/pull/105140)).

Example results running the following example command: `kurun run cmd/examples/main.go -e VAULT_ADDR=https://vault.test:8200`, with default (`merge`) override type:

```
Containers:                                                                                                                                                                            
   kurun-99f16107a835271146d1b1fd0b692e8a7baa9315:                                                                                                                                      
     Container ID:   docker://b24dec502aaae769e9984f554a89a5432ea9d9f0b1262bbee885309c4c3bb83c                                                                                          
     Image:          docker.io/library/kurun-99f16107a835271146d1b1fd0b692e8a7baa9315:ccb03e31a6a965bbaeff3c1ec1223fa52b53bb8dea621b9a580169223700f7b8                                  
     Image ID:       docker://sha256:ccb03e31a6a965bbaeff3c1ec1223fa52b53bb8dea621b9a580169223700f7b8                                                                                   
     Port:           <none>                                                                                                                                                             
     Host Port:      <none>                                                                                                                                                             
     State:          Running                                                                                                                                                            
       Started:      Fri, 03 Mar 2023 17:47:20 +0100                                                                                                                                    
     Ready:          True                                                                                                                                                               
     Restart Count:  0                                                                                                                                                                  
     Limits:                                                                                                                                                                            
       cpu:     100m                                                                                                                                                                    
       memory:  128Mi                                                                                                                                                                   
     Requests:                                                                                                                                                                          
       cpu:        100m                                                                                                                                                                 
       memory:     128Mi                                                                                                                                                                
     Environment:  <none>                                                                                                                                                               
     Mounts:                                                                                                                                                                            
       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gqrgm (ro)
```

With `strategic` override type:

```
Containers:                                                                                                                                                                            
   kurun-99f16107a835271146d1b1fd0b692e8a7baa9315:                                                                                                                                      
     Container ID:  docker://5a4e585c88ca15a07592409451e41438d81eb826c7637e2b0b4b552ea4849bdc                                                                                           
     Image:         docker.io/library/kurun-99f16107a835271146d1b1fd0b692e8a7baa9315:ccb03e31a6a965bbaeff3c1ec1223fa52b53bb8dea621b9a580169223700f7b8                                   
     Image ID:      docker://sha256:ccb03e31a6a965bbaeff3c1ec1223fa52b53bb8dea621b9a580169223700f7b8                                                                                    
     Port:          <none>                                                                                                                                                              
     Host Port:     <none>                                                                                                                                                              
     Command:                                                                                                                                                                           
       sh                                                                                                                                                                               
       -c                                                                                                                                                                               
       sleep 1 && /main                                                                                                                                                                 
     State:          Running                                                                                                                                                            
       Started:      Mon, 06 Mar 2023 10:28:15 +0100                                                                                                                                    
     Ready:          True                                                                                                                                                               
     Restart Count:  0                                                                                                                                                                  
     Limits:                                                                                                                                                                            
       cpu:     100m                                                                                                                                                                    
       memory:  128Mi                                                                                                                                                                   
     Requests:                                                                                                                                                                          
       cpu:     100m                                                                                                                                                                    
       memory:  128Mi                                                                                                                                                                   
     Environment:                                                                                                                                                                       
       VAULT_ADDR:  https://vault.test:8200                                                                                                                                             
     Mounts:                                                                                                                                                                            
       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-t8mp6 (ro)
```

The next issue this PR addresses is that kubectl's `--seviceaccount` flag has been deprecated and removed since 1.24, so it is only configurable using the overrides flag now. Adding multiple `--overrides` flags to a kubectl command results in only the last one being applied however, so anything specified here gets merged with kurun's default limits override first, and then applied as one JSON.

The third thing is a feature, since we already configuring a lot with the `--overrides` flag, it has been added to `kurun run`, the JSON string specified here also gets merged to the object that will be passed to the `--overrides` flag of the `kubectl run` command.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To fix bugs around kubectl run's `--overrides` flag, also to deal with the deprecated `--serviceaccount` flag.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~